### PR TITLE
src/json: created templates for features

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,27 +1,55 @@
 #!/usr/bin/env python3
 
+import sys
 import json
 
 from pathlib import Path
 
+def error_context(data, error, context):
+
+	lines  = data.split("\n")
+	center = error.lineno - 1
+	start  = max(center - context, 0);
+	stop   = min(center + context, len(lines) - 1);
+	digits = len(str(error.lineno))
+	out    = "%%%dd: %%s" % digits
+	text   = []
+
+	for index in range(start, stop + 1):
+		text.append(out % (index + 1, lines[index]))
+		if index == center:
+			text.append("-" * (digits + error.colno + 1) + "^")
+
+	return "\n".join(text)
+
 def compile_definitions():
 
-	compiled = json.loads(Path("./src/json/template.json").read_text())
+	compiled = json.loads(Path("./src/json/definitions.json").read_text())
 
 	# compile all of the json data into a monolithic file
 	for file in Path("./src/json").iterdir():
 		
-		if not file.is_dir():
+		# we want every folder except the templates
+		if not file.is_dir() or file.name == "templates":
 			continue
 
 		definitions = []
 
 		for definition in file.iterdir():
-			definitions.append(json.loads(definition.read_text()))
+
+			data = definition.read_text()
+
+			try:
+				definitions.append(json.loads(data))
+			except json.decoder.JSONDecodeError as error:
+				print("Error loading: " + str(definition), file=sys.stderr)
+				print(error_context(data, error, 3), file=sys.stderr)
+				print(error, file=sys.stderr)
+				sys.exit(1)
 
 		compiled[file.name] = definitions
 
-	print(json.dumps(compiled, indent=2))
+	# print(json.dumps(compiled, indent=2))
 	return compiled
 
 def main():
@@ -30,11 +58,15 @@ def main():
 	definitions_literal  = json_template_string
 	definitions          = json.loads(definitions_literal);
 
-	compile_definitions()
-
 	Path("definitions.js").write_text(
 		f"const definitions = {json_template_string};"
 	)
+
+	# compiled = compile_definitions()
+
+	# Path("definitions_.js").write_text(
+	# 	f"const definitions = {json.dumps(compiled, indent=2)};"
+	# )	
 
 if __name__ == "__main__":
 	main()

--- a/src/json/definitions.json
+++ b/src/json/definitions.json
@@ -1,0 +1,75 @@
+{
+  "stats": {
+    "names": [
+      "hp",
+      "str",
+      "mag",
+      "dex",
+      "spd",
+      "def",
+      "res",
+      "cha",
+      "mov"
+    ],
+    "linked": [
+      [
+        "str",
+        "pmt"
+      ],
+      [
+        "mag",
+        "mmt"
+      ],
+      [
+        "dex",
+        "hit"
+      ],
+      [
+        "dex",
+        "crit"
+      ],
+      [
+        "cha",
+        "cravo"
+      ],
+      [
+        "cha",
+        "newcrit"
+      ],
+      [
+        "spd",
+        "avo"
+      ],
+      [
+        "def",
+        "pdr"
+      ],
+      [
+        "res",
+        "mdr"
+      ],
+      [
+        null,
+        "minrng"
+      ],
+      [
+        null,
+        "maxrng"
+      ]
+    ]
+  },
+  "skills": [
+    "Axes",
+    "Swords",
+    "Lances",
+    "Brawl",
+    "Archery",
+    "Reason",
+    "Faith",
+    "Guile",
+    "Authority",
+    "Armor",
+    "Riding",
+    "Flying"
+  ]
+}

--- a/src/json/templates/ability.json
+++ b/src/json/templates/ability.json
@@ -1,0 +1,36 @@
+{
+    "name": "Ability Template",
+    "description": "This is a template ability; it doesn't do anything.",
+    "type": "Passive Conditional",
+    "weapon": "Swords Lances Axes Reason Guile Faith Bows Other",
+    "requires": "",
+    "modifiers": {
+        "hp": 0,
+        "sp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0,
+
+        "pmt": 0,
+        "mmt": 0,
+        "pdr": 0,
+        "mdr": 0,
+        "hit": 0,
+        "avo": 0,
+        "crit": 0,
+        "cravo": 0,
+
+        "minrng": 0,
+        "maxrng": 0,
+
+        "mov": 0
+    },
+
+    "comment": "Items in modifers can either be integers or string expressions",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/art.json
+++ b/src/json/templates/art.json
@@ -1,0 +1,27 @@
+{
+    "name": "Template Art",
+    "type": "Swords Lances Axes Reason Guile Faith Bows Movement Other",
+    "description": "This is a art represents not using an art. Serves as a template/placeholder",
+    "requires": "",
+    "modifiers": {
+        "pmt": 0,
+        "mmt": 0,
+        "pdr": 0,
+        "mdr": 0,
+        "hit": 0,
+        "avo": 0,
+        "crit": 0,
+        "cravo": 0,
+        "minrng": 1,
+        "maxrng": 1,
+
+        "sp": 0,
+        "uses": 0,
+        "charges": 0,
+        "tokens": 0
+    },
+
+    "comment": "Items in modifers can either be integers or string expressions",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/battalion.json
+++ b/src/json/templates/battalion.json
@@ -1,0 +1,43 @@
+{
+    "name": "Battalion Template",
+    "description": "This is a template battalion; it can't be used",
+    "rarity": "Bronze Silver Gold",
+    "type": "Martial Armor Flying Riding Other",
+    "requires": "",
+
+    "modifiers": {
+        "hp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0,
+        "mov": 0
+    },
+
+    "gambit": {
+        "name": "Gambit Name",
+        "description": "A description of the gambit",
+        "modifiers": {
+            "pmt": 0,
+            "mmt": 0,
+            "pdr": 0,
+            "mdr": 0,
+            "hit": 0,
+            "avo": 0,
+            "crit": 0,
+            "cravo": 0,
+            "minrng": 1,
+            "maxrng": 1,
+
+            "uses": 0
+        },
+        "magical": false
+    },
+
+    "comment": "Items in growth, modifiers, and mount should be integers",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/class.json
+++ b/src/json/templates/class.json
@@ -1,0 +1,43 @@
+{
+    "name": "Class Template",
+    "description": "This is a template class; it can't be used",
+    "type": "Martial Armor Flying Riding Other",
+    "tier": "Starting Advanced",
+    "requires": "",
+    "abilities": [],
+    "growths": {
+        "hp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0
+      },
+    "modifiers": {
+        "hp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0,
+        "mov": 0
+    },
+    "mount": {
+        "hp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0
+    },
+
+    "comment": "Items in growth, modifiers, and mount should be integers",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/equipment.json
+++ b/src/json/templates/equipment.json
@@ -1,0 +1,36 @@
+{
+    "name": "Placeholder",
+    "description": "This is a template.",
+    "type": "Generic",
+    "requires": "",
+    "modifiers": {
+        "hp": 0,
+        "sp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0,
+
+        "pmt": 0,
+        "mmt": 0,
+        "pdr": 0,
+        "mdr": 0,
+        "hit": 0,
+        "avo": 0,
+        "crit": 0,
+        "cravo": 0,
+
+        "minrng": 0,
+        "maxrng": 0,
+
+        "mov": 0
+    },
+    "magical": false,
+
+    "comment": "Items in modifers can either be integers or string expressions",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/status.json
+++ b/src/json/templates/status.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ability Template",
+    "description": "This is a template status; it doesn't do anything.",
+
+    "modifiers": {
+        "hp": 0,
+        "sp": 0,
+        "str": 0,
+        "mag": 0,
+        "dex": 0,
+        "spd": 0,
+        "def": 0,
+        "res": 0,
+        "cha": 0,
+
+        "pmt": 0,
+        "mmt": 0,
+        "pdr": 0,
+        "mdr": 0,
+        "hit": 0,
+        "avo": 0,
+        "crit": 0,
+        "cravo": 0,
+
+        "minrng": 0,
+        "maxrng": 0,
+
+        "mov": 0
+    },
+
+    "comment": "Items in modifers can either be integers or string expressions",
+    "tags": [],
+    "hidden": false
+}

--- a/src/json/templates/weapon.json
+++ b/src/json/templates/weapon.json
@@ -1,0 +1,27 @@
+{
+    "name": "Template Weapon",
+    "type": "Swords Lances Axes Reason Guile Faith Bows Other",
+    "description": "This is a template weapon and should not be used.",
+    "requires": "",
+    "price": 0,
+
+    "modifiers": {
+        "pmt": 0,
+        "mmt": 0,
+        "pdr": 0,
+        "mdr": 0,
+        "hit": 0,
+        "avo": 0,
+        "crit": 0,
+        "cravo": 0,
+        "minrng": 1,
+        "maxrng": 1,
+        "cost": 0,
+        "uses": 0
+    },
+    "magical": false,
+
+    "comment": "Items in modifers should be integers",
+    "tags": [],
+    "hidden": false
+}


### PR DESCRIPTION
Created templates for stand alone json file features, also added to build.py so that it will report json parsing error when building definitions.js, though currently is just discards the result.

Signed-off-by: Ryan Luchs <rluchs107@gmail.com>