### PR TITLE
Fixed wording of Harrowing

### DIFF
--- a/definitions.js
+++ b/definitions.js
@@ -2805,7 +2805,7 @@ const definitions = {
     },
     {
       "name": "Harrowing",
-      "description": "Double applied stat changes from this spell.",
+      "description": "Double stat changes of conditions applied by this spell.",
       "requires": "Guile C",
       "mttype": "else",
       "modifiers": {

--- a/src/json/arts/harrowing.json
+++ b/src/json/arts/harrowing.json
@@ -1,6 +1,6 @@
 {
   "name": "Harrowing",
-  "description": "Double applied stat changes from this spell.",
+  "description": "Double stat changes of conditions applied by this spell.",
   "requires": "Guile C",
   "mttype": "else",
   "modifiers": {


### PR DESCRIPTION
Harrowing was vague on wording, it's only meant to double stat changes of conditions applied by the spell it's used with, not all stat modifiers.

Signed-off-by: Ryan Luchs <rluchs107@gmail.com>